### PR TITLE
Fix output protection level

### DIFF
--- a/Sources/ISSoundAdditions/Sound.swift
+++ b/Sources/ISSoundAdditions/Sound.swift
@@ -13,5 +13,5 @@
 /// You can use the shared instance to change the output volume as well as
 /// mute and unmute.
 public enum Sound {
-  static let output = SoundOutputManager()
+  public static let output = SoundOutputManager()
 }


### PR DESCRIPTION
When trying to use Sound.output, you get an error saying "'output' is inaccessible due to 'internal' protection level". This is due to the output variable in Sound.swift not being public.